### PR TITLE
Allow users to pass parameters to metadata function

### DIFF
--- a/src/clj_dropbox_oauth2/dropbox.clj
+++ b/src/clj_dropbox_oauth2/dropbox.clj
@@ -27,9 +27,11 @@
 
 (defn metadata
   "Retrieves file/folder metadata"
-  [access-token path]
+  ([access-token path]
+   (metadata access-token path {}))
+  ([access-token path params]
   (let [url (format "https://api.dropbox.com/1/metadata/auto/%s" path)]
-    (parse-body (do-request oauth2/get access-token url))))
+    (parse-body (do-request oauth2/get access-token url {:query-params params})))))
 
 (defn files
   "Downloads a file"


### PR DESCRIPTION
Thank you for this awesome library. Small, concise and simple to use.

I am working on an app which reads folders/files metadata. Dropbox allows you add query parameters to that endpoint. I realised I don't really need `contents` part of the response, so instead of filtering the response on my own I can pass `list=false` and dropbox api will do that for me. Then this kind of response:

```
{:path /foo, :hash 74b0f257fed2ba8f370fbe2e18e1d313, :modifier nil, :revision 83128581, :icon folder,
:modified Wed, 07 Oct 2015 20:50:08 +0000, :rev 4f4710500376537, :size 0 bytes, :is_dir true, :root
dropbox, :read_only false, :bytes 0, :contents [{:path /foo/bar, :modifier nil, :revision 83128582, :icon
folder, :modified Wed, 07 Oct 2015 20:50:22 +0000, :rev 4f4710600376537, :size 0 bytes, :is_dir true,
:root dropbox, :read_only false, :bytes 0, :thumb_exists false}], :thumb_exists false}
```

becomes this:

```
{:path /foo, :modifier nil, :revision 83128581, :icon folder, :modified Wed, 07 Oct 2015 20:50:08 +0000,
:rev 4f4710500376537, :size 0 bytes, :is_dir true, :root dropbox, :read_only false, :bytes 0, :thumb_exists
false}
```

Little thing but can be helpful :)
